### PR TITLE
Improve call graph API and docs

### DIFF
--- a/who_calls/__init__.py
+++ b/who_calls/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for the who-calls project."""
+
+from .who_calls import build_call_graph, print_caller_tree, CallGraph
+
+__all__ = ["build_call_graph", "print_caller_tree", "CallGraph"]

--- a/who_calls/cli.py
+++ b/who_calls/cli.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
+"""Command line interface for ``who-calls``."""
 import argparse
 import re
 import pathlib
 
-from who_calls import who_calls
+from who_calls import build_call_graph, print_caller_tree
 
 DEFAULT_EXCLUDE = re.compile(r"\.git|\.venv|\.cache|tests")
 
@@ -11,8 +13,10 @@ DEFAULT_EXCLUDE = re.compile(r"\.git|\.venv|\.cache|tests")
 # ─────────────────────────────────────────────────────────────
 #  Main
 # ─────────────────────────────────────────────────────────────
-#
+
 def main() -> None:
+    """Entry point for the ``who-calls`` command line interface."""
+
     ap = argparse.ArgumentParser(description="Static caller tree explorer")
     ap.add_argument("function", help="target function name (or fully‑qualified)")
     ap.add_argument("--root", default=".", help="source root directory")
@@ -21,11 +25,18 @@ def main() -> None:
         default=DEFAULT_EXCLUDE.pattern,
         help="regex of paths to ignore (default: %(default)s)",
     )
+    ap.add_argument(
+        "--only",
+        default=None,
+        help="regex of dotted names to include in the graph",
+    )
     args = ap.parse_args()
 
     rx = re.compile(args.exclude)
-    g, srcm, linem = who_calls.build_call_graph(pathlib.Path(args.root), rx)
-    who_calls.print_caller_tree(g, srcm, linem, args.function)
+    graph = build_call_graph(pathlib.Path(args.root), rx)
+    if args.only:
+        graph = graph.filtered(re.compile(args.only))
+    print_caller_tree(graph, args.function)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `__init__.py` to expose high level API
- refactor call graph builder to return a dataclass
- update CLI to use new API
- add ability to filter the call graph via regex

## Testing
- `python -m compileall -q who_calls`


------
https://chatgpt.com/codex/tasks/task_e_6856db9e00e0832d917bc176d7808c67